### PR TITLE
Get rspec-puppet working

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  symlinks:
+    module1: "#{source_dir}"
+  repositories:
+    stdlib:
+      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0
+  - 2.2
+install:
+  - bundle install
+script:
+  - bundle exec rake validate
+  - bundle exec rake lint
+  - bundle exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,62 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    hiera (3.1.2)
+      json_pure
+    json (1.8.3)
+    json_pure (1.8.3)
+    metaclass (0.0.4)
+    metadata-json-lint (0.0.11)
+      json
+      spdx-licenses (~> 1.0)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    puppet (4.4.2)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-syntax (2.1.0)
+      rake
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (11.1.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.4.0)
+      rspec
+    rspec-support (3.4.1)
+    spdx-licenses (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  facter (>= 1.7.0)
+  metadata-json-lint
+  puppet (>= 3.3)
+  puppet-lint (>= 1.0.0)
+  puppetlabs_spec_helper (>= 1.0.0)
+  rspec-puppet
+
+BUNDLED WITH
+   1.12.3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # module1
 
+[![Build Status](https://travis-ci.org/chrisbelyea/module1.svg?branch=master)](https://travis-ci.org/chrisbelyea/module1)
+
 #### Table of Contents
 
 1. [Description](#description)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,5 +44,4 @@
 #
 class module1 {
 
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,12 +4,11 @@
   "author": "zdog59",
   "summary": "first module",
   "license": "Apache-2.0",
-  "source": "",
-  "project_page": null,
-  "issues_url": null,
+  "source": "https://github.com/zdog59/module1.git",
+  "project_page": "https://github.com/zdog59/module1",
+  "issues_url": "https://github.com/zdog59/module1/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
   ],
   "data_provider": null
 }
-


### PR DESCRIPTION
Fixes issue #1. This commit adds:
- _.fixtures.yml_ for specifying spec fixtures
- _.rspec_ for setting default rspec output style
- _.travis.yml_ for automated CI jobs with [Travis CI](https://travis-ci.org)
